### PR TITLE
Add Python API tutorial for object recognition

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,7 @@
 - [Earth Engine Python API Colab Setup](https://colab.sandbox.google.com/github/google/earthengine-api/blob/master/python/examples/ipynb/ee-api-colab-setup.ipynb)
 - [Earth Engine TensorFlow demonstration notebook](https://colab.sandbox.google.com/github/google/earthengine-api/blob/master/python/examples/ipynb/TF_demo1_keras.ipynb)
 - [Earth Lab - Calculating the area of polygons in Google Earth Engine](https://www.earthdatascience.org/tutorials/basic-polygon-operations-google-earth-engine/)
+- [Symantic Segmentation of GEE High Resolution Imagery](https://gist.github.com/mortcanty/ac4c48e3d10e89676b7fe9b3a6f1ba3a)
 
 ## R
 


### PR DESCRIPTION
Hi Wu!

I'm requesting a new entry for a tutorial by Mort Canty ([GH](https://github.com/mortcanty), [Twitter](https://twitter.com/CantyMort)) that wasn't a good fit for us to host as an [EE Community Tutorial](https://developers.google.com/earth-engine/tutorials/community/explore) (see [issue](https://github.com/google/earthengine-community/issues/453)).

Thanks for your consideration